### PR TITLE
fix: Require Yunohost 12 or higher to force bookworm, as openssl 3 is needed

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -23,7 +23,7 @@ code = "https://github.com/mollyim/mollysocket"
 fund = "https://opencollective.com/mollyim"
 
 [integration]
-yunohost = ">= 11.2.30"
+yunohost = ">= 12.0.0"
 helpers_version = "2.1"
 architectures = ["amd64","armhf","arm64"]
 multi_instance = true


### PR DESCRIPTION
The upstream binary cannot work on bullseye as openssl 3 is linked. Let’s make that official in the manifest and simply wait for bookworm to be the official stable for Yunohost before tagging the app as working.

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
